### PR TITLE
Persist BLE device and add rescan reconnect

### DIFF
--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -30,8 +30,7 @@ class _DemoRingScreenState extends State<DemoRingScreen> {
   @override
   void initState() {
     super.initState();
-    _ble.ensureInitialized();
-    _ble.autoConnectToBest('RGB_CONTROL_L');
+    _ble.connect('RGB_CONTROL_L');
 
     _statusSub = _ble.statusStream.listen((_) {
       if (!mounted) return;
@@ -63,7 +62,7 @@ class _DemoRingScreenState extends State<DemoRingScreen> {
 
     _reconnectTimer = Timer(Duration(seconds: delaySec), () async {
       if (!_ble.isConnected) {
-        await _ble.autoConnectToBest('RGB_CONTROL_L');
+        await _ble.connect('RGB_CONTROL_L');
       }
     });
   }
@@ -456,12 +455,13 @@ class _ConnectionIndicatorState extends State<_ConnectionIndicator> {
               ),
             ),
           ),
-          if (_ble.lastRssi != null)
-            IconButton(
-              onPressed: () => _ble.autoConnectToBest('RGB_CONTROL_L'),
-              icon: const Icon(Icons.sync, color: Colors.white),
-              tooltip: 'Переподключиться',
-            ),
+          IconButton(
+            onPressed: busy
+                ? null
+                : () => _ble.connect('RGB_CONTROL_L', forceScan: true),
+            icon: const Icon(Icons.sync, color: Colors.white),
+            tooltip: 'Переподключиться',
+          ),
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   permission_handler: ^11.3.1
   device_info_plus: ^10.1.0
   flutter_circle_color_picker: ^0.3.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- store connected BLE device ID in SharedPreferences and reuse on startup
- expose a reconnect button to force a fresh scan ignoring the saved address
- fix initialization race so launch reconnects immediately using the saved device

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ab7b6d548323b84198f981a2166c