### PR TITLE
Persist BLE device and add rescan reconnect

### DIFF
--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Менеджер BLE: ищет по имени, выбирает лучшую по RSSI и подключается.
 class BleManager {
@@ -24,6 +25,9 @@ class BleManager {
       StreamController<bool>.broadcast();
   bool _scanning = false;
 
+  SharedPreferences? _prefs;
+  static const _savedIdKey = 'saved_device_id';
+
   Stream<DeviceConnectionState> get statusStream => _stateCtrl.stream;
   Stream<bool> get scanningStream => _scanCtrl.stream;
   DeviceConnectionState get connectionState => _connState.value;
@@ -41,12 +45,20 @@ class BleManager {
 
   StreamSubscription<DiscoveredDevice>? _scanSub;
   StreamSubscription<ConnectionStateUpdate>? _connSub;
+
   bool _initialized = false;
+  Future<void>? _initFuture;
 
   Future<void> ensureInitialized() async {
     if (_initialized) return;
-    _initialized = true;
+    _initFuture ??= _init();
+    await _initFuture;
+  }
+
+  Future<void> _init() async {
     await _ensurePermissions();
+    _prefs = await SharedPreferences.getInstance();
+    _initialized = true;
   }
 
   Future<void> _ensurePermissions() async {
@@ -75,6 +87,39 @@ class BleManager {
       // Явный запрос не обязателен, но можно проверить статус:
       await Permission.bluetooth.request();
     }
+  }
+
+  Future<void> connect(String targetName, {bool forceScan = false}) async {
+    await ensureInitialized();
+    await disconnect();
+
+    if (forceScan) {
+      // Пользователь запросил переподключение, забываем сохранённое устройство.
+      await _prefs?.remove(_savedIdKey);
+      _deviceId.value = null;
+      _deviceName.value = null;
+      _lastRssi.value = null;
+    } else {
+      final savedId = _prefs?.getString(_savedIdKey);
+      if (savedId != null) {
+        _lastRssi.value = null;
+        _deviceName.value = targetName;
+        _deviceId.value = savedId;
+        _connSub?.cancel();
+        _update(DeviceConnectionState.connecting);
+
+        _connSub = _ble
+            .connectToDevice(id: savedId, servicesWithCharacteristicsToDiscover: {})
+            .listen((u) {
+          _update(u.connectionState);
+        }, onError: (_) {
+          _update(DeviceConnectionState.disconnected);
+        });
+        return;
+      }
+    }
+
+    await autoConnectToBest(targetName);
   }
 
   Future<void> autoConnectToBest(String targetName,
@@ -113,6 +158,7 @@ class BleManager {
     _lastRssi.value = best!.rssi;
     _deviceName.value = best!.name;
     _deviceId.value = best!.id;
+    await _prefs?.setString(_savedIdKey, best!.id);
 
     _connSub?.cancel();
     _update(DeviceConnectionState.connecting);

--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -30,8 +30,7 @@ class _DemoRingScreenState extends State<DemoRingScreen> {
   @override
   void initState() {
     super.initState();
-    _ble.ensureInitialized();
-    _ble.autoConnectToBest('RGB_CONTROL_L');
+    _ble.connect('RGB_CONTROL_L');
 
     _statusSub = _ble.statusStream.listen((_) {
       if (!mounted) return;
@@ -63,7 +62,7 @@ class _DemoRingScreenState extends State<DemoRingScreen> {
 
     _reconnectTimer = Timer(Duration(seconds: delaySec), () async {
       if (!_ble.isConnected) {
-        await _ble.autoConnectToBest('RGB_CONTROL_L');
+        await _ble.connect('RGB_CONTROL_L');
       }
     });
   }
@@ -456,12 +455,13 @@ class _ConnectionIndicatorState extends State<_ConnectionIndicator> {
               ),
             ),
           ),
-          if (_ble.lastRssi != null)
-            IconButton(
-              onPressed: () => _ble.autoConnectToBest('RGB_CONTROL_L'),
-              icon: const Icon(Icons.sync, color: Colors.white),
-              tooltip: 'Переподключиться',
-            ),
+          IconButton(
+            onPressed: busy
+                ? null
+                : () => _ble.connect('RGB_CONTROL_L', forceScan: true),
+            icon: const Icon(Icons.sync, color: Colors.white),
+            tooltip: 'Переподключиться',
+          ),
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   permission_handler: ^11.3.1
   device_info_plus: ^10.1.0
   flutter_circle_color_picker: ^0.3.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- store connected BLE device ID in SharedPreferences and reuse on startup
- expose a reconnect button to force a fresh scan ignoring the saved address
- fix initialization race so launch reconnects immediately using the saved device
- clear stored device ID when manual reconnect is requested to rescan for the strongest device

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ab7b6d548323b84198f981a2166c