### PR TITLE
feat: remember BLE device for faster reconnect

### DIFF
--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -456,12 +456,12 @@ class _ConnectionIndicatorState extends State<_ConnectionIndicator> {
               ),
             ),
           ),
-          if (_ble.lastRssi != null)
-            IconButton(
-              onPressed: () => _ble.autoConnectToBest('RGB_CONTROL_L'),
-              icon: const Icon(Icons.sync, color: Colors.white),
-              tooltip: 'Переподключиться',
-            ),
+          IconButton(
+            onPressed: () =>
+                _ble.autoConnectToBest('RGB_CONTROL_L', useCache: false),
+            icon: const Icon(Icons.sync, color: Colors.white),
+            tooltip: 'Переподключиться',
+          ),
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   permission_handler: ^11.3.1
   device_info_plus: ^10.1.0
   flutter_circle_color_picker: ^0.3.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- cache connected BLE device ID and auto-reconnect on next launch
- add manual reconnect button that searches for strongest device ignoring cache
- add shared_preferences dependency for device ID storage

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ce8af5648323a80ec06c1f8c4699