### PR TITLE
fix: show reconnection indicator immediately

### DIFF
--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -57,9 +57,16 @@ class _DemoRingScreenState extends State<DemoRingScreen> {
   void _scheduleReconnect() {
     if (_reconnectTimer?.isActive ?? false) return;
 
-    final exp = (_reconnectAttempt.clamp(0, 10) as int);
-    final delaySec = min(_reconnectMaxDelaySec, 1 << exp); // 1,2,4,8,16,30...
-    _reconnectAttempt++;
+    final attempt = _reconnectAttempt++;
+    if (attempt == 0) {
+      // Первое переподключение выполняем сразу, чтобы индикатор появился немедленно
+      unawaited(_ble.autoConnectToBest('RGB_CONTROL_L'));
+      return;
+    }
+
+    final exp = ((attempt - 1).clamp(0, 10) as int);
+    final delaySec =
+        min(_reconnectMaxDelaySec, 1 << exp); // 1,2,4,8,16,30...
 
     _reconnectTimer = Timer(Duration(seconds: delaySec), () async {
       if (!_ble.isConnected) {


### PR DESCRIPTION
## Summary
- start first BLE reconnect attempt without delay so indicator updates immediately

## Testing
- `dart format lib/screens/demo_ring_screen.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d284778c8323aafb5dd367bd34b5