### PR TITLE
Show reconnect button immediately

### DIFF
--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -456,12 +456,13 @@ class _ConnectionIndicatorState extends State<_ConnectionIndicator> {
               ),
             ),
           ),
-          if (_ble.lastRssi != null)
-            IconButton(
-              onPressed: () => _ble.autoConnectToBest('RGB_CONTROL_L'),
-              icon: const Icon(Icons.sync, color: Colors.white),
-              tooltip: 'Переподключиться',
-            ),
+          IconButton(
+            onPressed:
+                busy ? null : () => _ble.autoConnectToBest('RGB_CONTROL_L'),
+            icon: Icon(Icons.sync,
+                color: busy ? Colors.white54 : Colors.white),
+            tooltip: 'Переподключиться',
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- Always show reconnect icon button in connection indicator, disabling while scanning/connecting

## Testing
- `dart format lib/screens/demo_ring_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d5b67bfc8323a22a6272beb93eee