### PR TITLE
feat: apply device status via ble

### DIFF
--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -155,6 +155,25 @@ class BleManager {
     }
   }
 
+  /// Подписка на уведомления от характеристики.
+  /// Возвращает поток байтов или пустой поток,
+  /// если устройство не подключено.
+  Stream<List<int>> subscribeToCharacteristic({
+    required Uuid service,
+    required Uuid characteristic,
+  }) {
+    final id = connectedDeviceId;
+    if (id == null || !isConnected) {
+      return const Stream<List<int>>.empty();
+    }
+    final ch = QualifiedCharacteristic(
+      deviceId: id,
+      serviceId: service,
+      characteristicId: characteristic,
+    );
+    return _ble.subscribeToCharacteristic(ch);
+  }
+
   void _update(DeviceConnectionState s) {
     if (_connState.value != s) {
       _connState.value = s;

--- a/lib/services/rgb_service.dart
+++ b/lib/services/rgb_service.dart
@@ -49,4 +49,12 @@ class RgbService {
   static Future<void> onCommandNumber(int number) async {
     await _sendString("LED:$number\n");
   }
+
+  /// Поток уведомлений от устройства.
+  static Stream<List<int>> statusStream() {
+    return BleManager.instance.subscribeToCharacteristic(
+      service: _svc,
+      characteristic: _ch,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- listen to BLE characteristic notifications
- expose status stream and update UI switches from semicolon packet

## Testing
- `dart format lib/ble_manager.dart lib/services/rgb_service.dart lib/screens/demo_ring_screen.dart` (failed: command not found)
- `flutter test` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae9fbb412c832399a3e28b9494d31d