### PR TITLE
Disable blink and auto-color when selecting color

### DIFF
--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -251,11 +251,27 @@ class _DemoRingScreenState extends State<DemoRingScreen> {
                             initialColor: _currentColor,
                             enabled: _isOn && connected,
                             onChanged: (c) {
+                              bool disablePolice = false;
+                              bool disableAuto = false;
                               setState(() {
                                 _currentColor = c;
                                 _selectedColor = c;
+                                if (_policeMode) {
+                                  _policeMode = false;
+                                  disablePolice = true;
+                                }
+                                if (_autoColorMode) {
+                                  _autoColorMode = false;
+                                  disableAuto = true;
+                                }
                               });
                               if (connected) {
+                                if (disablePolice) {
+                                  RgbService.onPoliceMode(false);
+                                }
+                                if (disableAuto) {
+                                  RgbService.onAutoColor(false);
+                                }
                                 RgbService.onColorChanged(c, isOn: _isOn);
                               }
                             },


### PR DESCRIPTION
## Summary
- stop blink and auto-color modes when a manual color is chosen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b00d8df0a0832387323d9b3691409e