### PR TITLE
feat: cache BLE MAC for quick reconnect

### DIFF
--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -698,8 +698,10 @@ class _ConnectionIndicatorState extends State<_ConnectionIndicator> {
             ),
           ),
           IconButton(
-            onPressed:
-                busy ? null : () => _ble.autoConnectToBest('RGB_CONTROL_L'),
+            onPressed: busy
+                ? null
+                : () =>
+                    _ble.autoConnectToBest('RGB_CONTROL_L', forceScan: true),
             icon: Icon(Icons.sync, color: busy ? Colors.white54 : Colors.white),
             tooltip: 'Переподключиться',
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   permission_handler: ^11.3.1
   device_info_plus: ^10.1.0
   flutter_circle_color_picker: ^0.3.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- persist last connected BLE device MAC using SharedPreferences
- skip name scan when MAC is known and allow manual rescan to update
- wire reconnect button to force rescan

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/ble_manager.dart lib/screens/demo_ring_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be91b6ef948323a87ce2826509d833