### PR TITLE
fix: await BLE subscription cancellation

### DIFF
--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -86,7 +86,7 @@ class BleManager {
     _deviceId.value = id;
     _deviceName.value = null;
 
-    _connSub?.cancel();
+    await _connSub?.cancel();
     _update(DeviceConnectionState.connecting);
 
     final completer = Completer<DeviceConnectionState>();
@@ -133,7 +133,7 @@ class BleManager {
 
     _setScanning(true);
     DiscoveredDevice? best;
-    _scanSub?.cancel();
+    await _scanSub?.cancel();
     _scanSub = _ble
         .scanForDevices(
           withServices: const [],
@@ -163,7 +163,7 @@ class BleManager {
     _deviceId.value = best!.id;
     await prefs.setString(_prefsDeviceKey, best!.id);
 
-    _connSub?.cancel();
+    await _connSub?.cancel();
     _update(DeviceConnectionState.connecting);
 
     _connSub = _ble


### PR DESCRIPTION
## Summary
- ensure BLE connections await cancellation of previous subscriptions
- wait for previous scan to stop before starting a new BLE scan

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be9d22e8248323ba0859bb5a0920d6