### PR TITLE
Enable reconnecting to new BLE devices

### DIFF
--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -186,6 +186,15 @@ class BleManager {
     _update(DeviceConnectionState.disconnected);
   }
 
+  /// Forget previously saved device identifier so that the next
+  /// connection attempt will scan for a new device.
+  Future<void> forgetDevice() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsDeviceKey);
+    _deviceId.value = null;
+    _deviceName.value = null;
+  }
+
   Future<void> writeBytes({
     required Uuid service,
     required Uuid characteristic,

--- a/lib/screens/demo_ring_screen.dart
+++ b/lib/screens/demo_ring_screen.dart
@@ -700,8 +700,11 @@ class _ConnectionIndicatorState extends State<_ConnectionIndicator> {
           IconButton(
             onPressed: busy
                 ? null
-                : () =>
-                    _ble.autoConnectToBest('RGB_CONTROL_L', forceScan: true),
+                : () async {
+                    await _ble.forgetDevice();
+                    await _ble.autoConnectToBest('RGB_CONTROL_L',
+                        forceScan: true);
+                  },
             icon: Icon(Icons.sync, color: busy ? Colors.white54 : Colors.white),
             tooltip: 'Переподключиться',
           ),


### PR DESCRIPTION
## Summary
- add `forgetDevice` in `BleManager` to clear saved MAC and name
- clear saved device before forcing a rescan so a different device can be paired

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bedeb37154832395836b621050c3d2